### PR TITLE
Move columns by dragging the column header

### DIFF
--- a/src/tailor/app.py
+++ b/src/tailor/app.py
@@ -119,6 +119,7 @@ class Application(QtCore.QObject):
         self.ui.actionClear_Menu.triggered.connect(self.clear_recent_files_menu)
 
         # user interface events
+        self.ui.data_view.horizontalHeader().sectionMoved.connect(self.column_moved)
         self.ui.tabWidget.currentChanged.connect(self.tab_changed)
         self.ui.tabWidget.tabCloseRequested.connect(self.close_tab)
         self.ui.name_edit.textEdited.connect(self.rename_column)
@@ -273,6 +274,28 @@ class Application(QtCore.QObject):
 
         self.selection = self.ui.data_view.selectionModel()
         self.selection.selectionChanged.connect(self.selection_changed)
+
+    def column_moved(self, logidx, oldidx, newidx):
+        """Move column in reaction to UI signal.
+
+        Dragging a column to a new location triggers execution of this method.
+        Since the UI only reorders the column visually and does not change the
+        underlying data, we will first restore the visual ordering and then move
+        the column in the underlying data instead.
+
+        Args:
+            logidx (int): the logical column index (index in the dataframe)
+            oldidx (int): the old visual index
+            newidx (int): the new visual index
+        """
+        # Restore visual ordering (visually moving back the column)
+        # Prevent triggering this method while moving back the column
+        header = self.ui.data_view.horizontalHeader()
+        header.blockSignals(True)
+        self.ui.data_view.horizontalHeader().moveSection(newidx, oldidx)
+        header.blockSignals(False)
+        # Now, move the underlying data
+        self.data_model.moveColumn(sourceColumn=oldidx, destinationChild=newidx)
 
     def eventFilter(self, watched, event):
         """Catch PySide6 events.

--- a/src/tailor/app.py
+++ b/src/tailor/app.py
@@ -268,6 +268,8 @@ class Application(QtCore.QObject):
         self.ui.data_view.setDragDropMode(self.ui.data_view.NoDragDrop)
         header = self.ui.data_view.horizontalHeader()
         header.setSectionsMovable(True)
+        header.setSectionResizeMode(QtWidgets.QHeaderView.ResizeToContents)
+        header.setMinimumSectionSize(header.defaultSectionSize())
 
         self.selection = self.ui.data_view.selectionModel()
         self.selection.selectionChanged.connect(self.selection_changed)

--- a/src/tailor/app.py
+++ b/src/tailor/app.py
@@ -293,9 +293,15 @@ class Application(QtCore.QObject):
         header = self.ui.data_view.horizontalHeader()
         header.blockSignals(True)
         self.ui.data_view.horizontalHeader().moveSection(newidx, oldidx)
-        header.blockSignals(False)
         # Now, move the underlying data
         self.data_model.moveColumn(sourceColumn=oldidx, destinationChild=newidx)
+        # BUGFIX: a probable bug in Qt6 messes up the selection when moving
+        # columns. To prevent this, manually select the column at the new
+        # location.
+        self.ui.data_view.selectColumn(newidx)
+        # Unblock signals as late as possible. When you unblock to early, the
+        # Qt6 crashes without an error message.
+        header.blockSignals(False)
 
     def eventFilter(self, watched, event):
         """Catch PySide6 events.

--- a/src/tailor/app.py
+++ b/src/tailor/app.py
@@ -265,7 +265,9 @@ class Application(QtCore.QObject):
 
     def _set_view_and_selection_model(self):
         self.ui.data_view.setModel(self.data_model)
-        self.ui.data_view.setDragDropMode(self.ui.data_view.InternalMove)
+        self.ui.data_view.setDragDropMode(self.ui.data_view.NoDragDrop)
+        header = self.ui.data_view.horizontalHeader()
+        header.setSectionsMovable(True)
 
         self.selection = self.ui.data_view.selectionModel()
         self.selection.selectionChanged.connect(self.selection_changed)

--- a/src/tailor/data_model.py
+++ b/src/tailor/data_model.py
@@ -187,6 +187,52 @@ class DataModel(QtCore.QAbstractTableModel):
         self.endRemoveColumns()
         return True
 
+    def moveColumn(
+        self,
+        sourceParent=None,
+        sourceColumn=0,
+        destinationParent=None,
+        destinationChild=0,
+    ):
+        """Move a column from source to destination.
+
+        Args:
+            sourceParent (Union[PySide6.QtCore.QModelIndex,
+                PySide6.QtCore.QPersistentModelIndex]): a QModelIndex pointing
+                to the model (ignored).
+            sourceColumn (int): the index of the source column.
+            destinationParent (Union[PySide6.QtCore.QModelIndex,
+                PySide6.QtCore.QPersistentModelIndex]): a QModelIndex pointing to
+                the model (ignored).
+            destinationChild (int): the index of the destination column.
+
+        Returns:
+            bool: True if the column was succesfully moved.
+        """
+        if sourceParent is None:
+            sourceParent = QtCore.QModelIndex()
+        if destinationParent is None:
+            destinationParent = sourceParent
+        # signal that we are going to move the column
+        self.beginMoveColumns(
+            sourceParent,
+            sourceColumn,
+            sourceColumn,
+            destinationParent,
+            destinationChild,
+        )
+        columns = self._data.columns.to_list()
+        col_name = columns[sourceColumn]
+        # Delete column at source index
+        del columns[sourceColumn]
+        # And insert at destination index
+        columns.insert(destinationChild, col_name)
+        # get new dataframe in correct order
+        self._data = self._data[columns]
+        # we're done moving the column
+        self.endMoveColumns()
+        return True
+
     def removeRow(self, row, parent=None):
         """Remove a single row.
 


### PR DESCRIPTION
You can drag columns to reorder the data. This was a bit of a hack, unfortunately, possibly triggering some Qt6 bugs. The documentation is clearly lagging in this regard.

Also switched on the autoresize option for the column widths.