### PR TITLE
Do not ignore NaN values in fit

### DIFF
--- a/src/tailor/plot_tab.py
+++ b/src/tailor/plot_tab.py
@@ -565,7 +565,7 @@ class PlotTab:
         if y_err is not None:
             kwargs["weights"] = 1 / y_err
         try:
-            self.fit = self.model.fit(y, **kwargs, nan_policy="omit")
+            self.fit = self.model.fit(y, **kwargs)
         except Exception as exc:
             self.main_window.statusbar.showMessage(f"FIT FAILED: {exc}")
         else:


### PR DESCRIPTION
Ignoring NaN values results in very cryptic error messages later on.