### PR TITLE
Fix crashes when moving columns

### DIFF
--- a/src/tailor/app.py
+++ b/src/tailor/app.py
@@ -119,6 +119,7 @@ class Application(QtCore.QObject):
         self.ui.actionClear_Menu.triggered.connect(self.clear_recent_files_menu)
 
         # user interface events
+        self.ui.data_view.horizontalHeader().sectionMoved.connect(self.column_moved)
         self.ui.tabWidget.currentChanged.connect(self.tab_changed)
         self.ui.tabWidget.tabCloseRequested.connect(self.close_tab)
         self.ui.name_edit.textEdited.connect(self.rename_column)
@@ -273,6 +274,26 @@ class Application(QtCore.QObject):
 
         self.selection = self.ui.data_view.selectionModel()
         self.selection.selectionChanged.connect(self.selection_changed)
+
+    def column_moved(self, logidx, oldidx, newidx):
+        """Move column in reaction to UI signal.
+
+        Dragging a column to a new location triggers execution of this method.
+        Since the UI only reorders the column visually and does not change the
+        underlying data, we will store the ordering in the data model.
+
+        Args:
+            logidx (int): the logical column index (index in the dataframe)
+            oldidx (int): the old visual index
+            newidx (int): the new visual index
+        """
+        self.data_model._column_order = self.get_column_ordering()
+
+    def get_column_ordering(self):
+        """Return the logical order of columns in the table view."""
+        header = self.ui.data_view.horizontalHeader()
+        n_columns = len(self.data_model.get_column_names())
+        return [header.logicalIndex(i) for i in range(n_columns)]
 
     def eventFilter(self, watched, event):
         """Catch PySide6 events.

--- a/src/tailor/app.py
+++ b/src/tailor/app.py
@@ -119,7 +119,6 @@ class Application(QtCore.QObject):
         self.ui.actionClear_Menu.triggered.connect(self.clear_recent_files_menu)
 
         # user interface events
-        self.ui.data_view.horizontalHeader().sectionMoved.connect(self.column_moved)
         self.ui.tabWidget.currentChanged.connect(self.tab_changed)
         self.ui.tabWidget.tabCloseRequested.connect(self.close_tab)
         self.ui.name_edit.textEdited.connect(self.rename_column)
@@ -274,34 +273,6 @@ class Application(QtCore.QObject):
 
         self.selection = self.ui.data_view.selectionModel()
         self.selection.selectionChanged.connect(self.selection_changed)
-
-    def column_moved(self, logidx, oldidx, newidx):
-        """Move column in reaction to UI signal.
-
-        Dragging a column to a new location triggers execution of this method.
-        Since the UI only reorders the column visually and does not change the
-        underlying data, we will first restore the visual ordering and then move
-        the column in the underlying data instead.
-
-        Args:
-            logidx (int): the logical column index (index in the dataframe)
-            oldidx (int): the old visual index
-            newidx (int): the new visual index
-        """
-        # Restore visual ordering (visually moving back the column)
-        # Prevent triggering this method while moving back the column
-        header = self.ui.data_view.horizontalHeader()
-        header.blockSignals(True)
-        self.ui.data_view.horizontalHeader().moveSection(newidx, oldidx)
-        # Now, move the underlying data
-        self.data_model.moveColumn(sourceColumn=oldidx, destinationChild=newidx)
-        # BUGFIX: a probable bug in Qt6 messes up the selection when moving
-        # columns. To prevent this, manually select the column at the new
-        # location.
-        self.ui.data_view.selectColumn(newidx)
-        # Unblock signals as late as possible. When you unblock to early, the
-        # Qt6 crashes without an error message.
-        header.blockSignals(False)
 
     def eventFilter(self, watched, event):
         """Catch PySide6 events.

--- a/src/tailor/data_model.py
+++ b/src/tailor/data_model.py
@@ -27,6 +27,7 @@ class DataModel(QtCore.QAbstractTableModel):
     _new_col_num = 0
     _data = None
     _calculated_column_expression = None
+    _column_order = []
 
     def __init__(self, main_window):
         """Instantiate the class."""
@@ -35,6 +36,7 @@ class DataModel(QtCore.QAbstractTableModel):
         self.main_window = main_window
 
         self._data = pd.DataFrame.from_dict({"x": 5 * [np.nan], "y": 5 * [np.nan]})
+        self._column_order = list(range(len(self._data.columns)))
         self._calculated_column_expression = {}
 
     def rowCount(self, parent=None):
@@ -151,6 +153,7 @@ class DataModel(QtCore.QAbstractTableModel):
         Args:
             column: an integer column number to indicate the place of insertion.
             parent: a QModelIndex pointing to the model (ignored).
+            column_name: the name of the new column.
 
         Returns:
             True if the insertion was succesful, False otherwise.
@@ -161,6 +164,7 @@ class DataModel(QtCore.QAbstractTableModel):
         self.beginInsertColumns(QtCore.QModelIndex(), column, column)
         self._data.insert(column, column_name, np.nan)
         self.endInsertColumns()
+        self._column_order = self.main_window.get_column_ordering()
         return True
 
     def removeColumn(self, column, parent=None):
@@ -185,6 +189,7 @@ class DataModel(QtCore.QAbstractTableModel):
             # not a calculated column
             pass
         self.endRemoveColumns()
+        self._column_order = self.main_window.get_column_ordering()
         return True
 
     def removeRow(self, row, parent=None):
@@ -468,9 +473,11 @@ class DataModel(QtCore.QAbstractTableModel):
         Args:
             save_obj: a dictionary to store the data and state.
         """
+        columns = self._data.columns[self._column_order]
+        df = self._data[columns]
         save_obj.update(
             {
-                "data": self._data.to_dict("list"),
+                "data": df.to_dict("list"),
                 "calculated_columns": self._calculated_column_expression,
                 "new_col_num": self._new_col_num,
             }
@@ -484,6 +491,7 @@ class DataModel(QtCore.QAbstractTableModel):
         """
         self.beginResetModel()
         self._data = pd.DataFrame.from_dict(save_obj["data"])
+        self._column_order = list(range(len(self._data.columns)))
         self._calculated_column_expression = save_obj["calculated_columns"]
         self._new_col_num = save_obj["new_col_num"]
         self.endResetModel()

--- a/src/tailor/data_model.py
+++ b/src/tailor/data_model.py
@@ -187,52 +187,6 @@ class DataModel(QtCore.QAbstractTableModel):
         self.endRemoveColumns()
         return True
 
-    def moveColumn(
-        self,
-        sourceParent=None,
-        sourceColumn=0,
-        destinationParent=None,
-        destinationChild=0,
-    ):
-        """Move a column from source to destination.
-
-        Args:
-            sourceParent (Union[PySide6.QtCore.QModelIndex,
-                PySide6.QtCore.QPersistentModelIndex]): a QModelIndex pointing
-                to the model (ignored).
-            sourceColumn (int): the index of the source column.
-            destinationParent (Union[PySide6.QtCore.QModelIndex,
-                PySide6.QtCore.QPersistentModelIndex]): a QModelIndex pointing to
-                the model (ignored).
-            destinationChild (int): the index of the destination column.
-
-        Returns:
-            bool: True if the column was succesfully moved.
-        """
-        if sourceParent is None:
-            sourceParent = QtCore.QModelIndex()
-        if destinationParent is None:
-            destinationParent = sourceParent
-        # signal that we are going to move the column
-        self.beginMoveColumns(
-            sourceParent,
-            sourceColumn,
-            sourceColumn,
-            destinationParent,
-            destinationChild,
-        )
-        columns = self._data.columns.to_list()
-        col_name = columns[sourceColumn]
-        # Delete column at source index
-        del columns[sourceColumn]
-        # And insert at destination index
-        columns.insert(destinationChild, col_name)
-        # get new dataframe in correct order
-        self._data = self._data[columns]
-        # we're done moving the column
-        self.endMoveColumns()
-        return True
-
     def removeRow(self, row, parent=None):
         """Remove a single row.
 


### PR DESCRIPTION
Instead of 'undoing' moving a column header and then reorder the data columns, keep track of the visual ordering of the logical columns. When saving, reorder the data in the saved project.