### PR TITLE
Speed up clearing cells

### DIFF
--- a/src/tailor/app.py
+++ b/src/tailor/app.py
@@ -408,7 +408,12 @@ class Application(QtCore.QObject):
     def clear_selected_cells(self):
         """Clear contents of selected cells."""
         for index in self.selection.selectedIndexes():
-            self.data_model.setData(index, "")
+            self.data_model.setData(index, "", skip_update=True)
+        # signal that ALL values may have changed using an invalid index
+        # this can be MUCH quicker than emitting signals for each cell
+        self.data_model.dataChanged.emit(QtCore.QModelIndex(), QtCore.QModelIndex())
+        # recalculate computed values once
+        self.data_model.recalculate_all_columns()
 
     def get_index_below_selected_cell(self):
         """Get index directly below the selected cell."""

--- a/src/tailor/data_model.py
+++ b/src/tailor/data_model.py
@@ -92,7 +92,7 @@ class DataModel(QtCore.QAbstractTableModel):
         # See Qt for Python docs -> Considerations -> API Changes
         return None
 
-    def setData(self, index, value, role=QtCore.Qt.EditRole):
+    def setData(self, index, value, role=QtCore.Qt.EditRole, *, skip_update=False):
         """Set (attributes of) data values.
 
         This method is used to set data values in the model. The role indicates
@@ -104,6 +104,9 @@ class DataModel(QtCore.QAbstractTableModel):
             value: the value to set.
             role: an ItemDataRole to indicate what type of information is
                 requested.
+            skip_update (boolean): if True, do not recalculate computed
+                cell values or signal that the current cell has changed. These
+                are both time-consuming operations.
 
         Returns:
             True if the data could be set. False otherwise.
@@ -118,8 +121,9 @@ class DataModel(QtCore.QAbstractTableModel):
             finally:
                 # FIXME: data changed, recalculate all columns; better to only
                 # recalculate the current row
-                self.recalculate_all_columns()
-            self.dataChanged.emit(index, index)
+                if not skip_update:
+                    self.recalculate_all_columns()
+                    self.dataChanged.emit(index, index)
             return True
         # Role not implemented
         return False


### PR DESCRIPTION
Postpone recalculating computed values and signalling that data changed until all cells are cleared and do it only once.