### PR TITLE
Fix toml decoding error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ windows/
 android/
 linux/
 django/
+
+# Briefcase dev logs
+*.dev.log

--- a/pruner.py
+++ b/pruner.py
@@ -4,7 +4,7 @@ import sys
 from glob import glob
 from pathlib import Path
 
-import toml
+import tomli
 
 
 def prune(base_dir, exclude, include):
@@ -33,12 +33,10 @@ def prune(base_dir, exclude, include):
 
 
 def main():
-    with open("pyproject.toml") as f:
-        config = toml.load(f)
+    with open("pyproject.toml", "rb") as f:
+        config = tomli.load(f)
     pruner_config = config["tool"]["pruner"][sys.platform]
-    prune(
-        pruner_config["base_dir"], pruner_config["exclude"], pruner_config["include"]
-    )
+    prune(pruner_config["base_dir"], pruner_config["exclude"], pruner_config["include"])
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ requires = [
     'lmfit>=1.0.3,<2.0.0',
     'scipy>=1.8.0,<2.0.0',
     'asteval>=0.9.26,<1.0.0',
-    'PySide6>=6.2.4,<6.3.0',
+    'PySide6_essentials>=6.3.2,<6.4.0',
     'pyqtgraph>=0.12.3,<0.13.0',
     'matplotlib>=3.5.1,<4.0.0',
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,8 @@ sources = ['src/tailor']
 requires = [
     'std-nslog',
     'appdirs>=1.4.4,<2.0.0',
-    'toml>=0.10.2,<1.0.0',
+    'tomli>=2.0.1,<3.0.0',
+    'tomli_w>=1.0.0,<2.0.0',
     'numpy>=1.22.1,<2.0.0',
     'pandas>=1.4.0,<2.0.0',
     'lmfit>=1.0.3,<2.0.0',

--- a/src/tailor/app.py
+++ b/src/tailor/app.py
@@ -430,7 +430,8 @@ class Application(QtCore.QObject):
         These values are used to update the column information in the user
         interface.
 
-        Args: selected: QItemSelection containing the newly selected events.
+        Args:
+            selected: QItemSelection containing the newly selected events.
             deselected: QItemSelection containing previously selected, and now
             deselected, items.
         """

--- a/src/tailor/config.py
+++ b/src/tailor/config.py
@@ -1,10 +1,10 @@
+import pathlib
 import sys
 from importlib import metadata as importlib_metadata
 
 import appdirs
-import toml
-import pathlib
-
+import tomli
+import tomli_w
 
 app_module = sys.modules["__main__"].__package__
 metadata = importlib_metadata.metadata(app_module)
@@ -18,8 +18,8 @@ def read_config():
     """Read configuration file."""
     config_path = get_config_path()
     if config_path.is_file():
-        with open(config_path) as f:
-            return toml.load(f)
+        with open(config_path, "rb") as f:
+            return tomli.load(f)
     else:
         return {}
 
@@ -32,7 +32,7 @@ def write_config(config):
     """
     create_config_dir()
     config_path = get_config_path()
-    toml_config = toml.dumps(config)
+    toml_config = tomli_w.dumps(config)
     with open(config_path, "w") as f:
         # separate TOML generation from writing to file, or an exception
         # generating TOML will result in an empty file


### PR DESCRIPTION
Paths on Windows with elements starting with an `x` caused crashes when decoding them. Turns out it was a bug in the `toml` library when encoding strings containing `\x`, as in `c:\users\xantippe`. See https://github.com/uiri/toml/issues/404. Fixed by moving to the `tomli` library which will be a part of the standard library starting with version 3.11.